### PR TITLE
added git ignore for cabal sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .gitignore
 dist
 junk
+.cabal-sandbox/
+cabal.sandbox.config


### PR DESCRIPTION
Cabal sandbox stuff wasn't in the gitignore.
