### PR TITLE
Update bounds on base

### DIFF
--- a/mikmod.cabal
+++ b/mikmod.cabal
@@ -28,7 +28,7 @@ library
   other-extensions:    ForeignFunctionInterface, EmptyDataDecls
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.8, bytestring
+  build-depends:       base >=4.7 && <4.9, bytestring
   
   -- Directories containing source files.
   -- hs-source-dirs:      


### PR DESCRIPTION
The bindings compile unchanged with newer base. Not sure if I should bump the version for this, so leaving as is for now.
